### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/hostname.cabal
+++ b/hostname.cabal
@@ -1,6 +1,6 @@
 Name:               hostname
 Version:            1.0
-Cabal-Version:      >= 1.2
+Cabal-Version:      >= 1.8
 Category:           Network
 Synopsis:           A very simple package providing a cross-platform means of determining the hostname
 License:            BSD3


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: hostname.cabal:15:38: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```